### PR TITLE
Allow detectSentiment as bool

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var LexModelBuildingService = new AWS.LexModelBuildingService({
 
 // CloudFormation sends everything as a String, have to coerce these values.
 const boolProperties = [
-  'childDirected'
+  'childDirected',
+  'detectSentiment'
 ]
 
 // CloudFormation sends everything as a String, have to coerce these values.


### PR DESCRIPTION
Hey, i'm trying to implement this package using the Lex support for AWS Comprehend. But i need to enforce bool transform to **detectSentiment** property on templates.

This may be useful for other people